### PR TITLE
eth: change get blockNumber code

### DIFF
--- a/eth/api.go
+++ b/eth/api.go
@@ -544,14 +544,9 @@ func (api *PrivateDebugAPI) getModifiedAccounts(startBlock, endBlock *types.Bloc
 
 // GetBlockReceipts returns all transaction receipts of the specified block.
 func (api *PrivateDebugAPI) GetBlockReceipts(blockHash common.Hash) ([]map[string]interface{}, error) {
-	blockNumber := rawdb.ReadHeaderNumber(api.eth.ChainDb(), blockHash)
 	if receipts := api.eth.blockchain.GetReceiptsByHash(blockHash); receipts != nil {
 		if block := api.eth.blockchain.GetBlockByHash(blockHash); block != nil {
-			if blockNumber != nil {
-				return ethapi.ToTxReceipts(*blockNumber, blockHash, receipts, block)
-			} else {
-				return ethapi.ToTxReceipts(0, blockHash, receipts, block)
-			}
+			return ethapi.ToTxReceipts(block.Header().Number.Uint64(), blockHash, receipts, block)
 		}
 	}
 	return nil, errors.New("unknown receipts")


### PR DESCRIPTION
Change getBlockReceipt get blockNumer from block header. The original code is from rawdb.
